### PR TITLE
(SIMP-910) Svckill outputs all results properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
     - PUPPET_VERSION="~> 4.0.0"
     - PUPPET_VERSION="~> 4.1.0"
     - PUPPET_VERSION="~> 4.2.0"
+    - PUPPET_VERSION="~> 4.3.0"
 matrix:
   fast_finish: true
   allow_failures:
@@ -40,10 +41,6 @@ matrix:
     - env: PUPPET_VERSION="~> 3.5.0"
     - env: PUPPET_VERSION="~> 3.6.0"
     - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
-    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
-    - env: PUPPET_VERSION="~> 4.0.0"
-    - env: PUPPET_VERSION="~> 4.1.0"
-    - env: PUPPET_VERSION="~> 4.2.0"
 
   exclude:
   # Ruby 1.8.7

--- a/build/pupmod-svckill.spec
+++ b/build/pupmod-svckill.spec
@@ -1,7 +1,7 @@
 Summary: Svckill Puppet Module
 Name: pupmod-svckill
-Version: 1.0.0
-Release: 6
+Version: 1.1.0
+Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -9,10 +9,10 @@ Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: puppet >= 3.3.0
 Buildarch: noarch
 Requires: simp-bootstrap >= 4.2.0
-Obsoletes: pupmod-timezone
-Obsoletes: pupmod-svckill-test
+Obsoletes: pupmod-timezone >= 0.0.1
+Obsoletes: pupmod-svckill-test >= 0.0.1
 
-Prefix: /etc/puppet/environments/simp/modules
+Prefix: %{_sysconfdir}/puppet/environments/simp/modules
 
 %description
 This Puppet module provides the capability to disable all services on
@@ -48,14 +48,16 @@ mkdir -p %{buildroot}/%{prefix}/svckill
 %post
 #!/bin/sh
 
-if [ -d /etc/puppet/environments/simp/modules/svckill/plugins ]; then
-  /bin/mv /etc/puppet/environments/simp/modules/svckill/plugins /etc/puppet/environments/simp/modules/common/plugins.bak
-fi
-
 %postun
 # Post uninstall stuff
 
 %changelog
+* Thu Mar 10 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.1.0-0
+- Added a 'verbose' option to svckill which will enumerate all actions on
+  services if enabled.
+- Ensure that all relevant messages are passed back via the 'to_s' method so
+  that PuppetDB can obtain a full report.
+
 * Wed Feb 24 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 1.0.0-6
 - Minor linting fixes
 

--- a/lib/puppet/provider/svckill/kill.rb
+++ b/lib/puppet/provider/svckill/kill.rb
@@ -212,6 +212,17 @@ Puppet::Type.type(:svckill).provide(:kill) do
   end
 
   def mode=(should)
+    @results = {
+      :stopped => {
+        :passed => [],
+        :failed => []
+      },
+      :disabled => {
+        :passed => [],
+        :failed => []
+      }
+    }
+
     @running_services.each_key do |svc|
       Puppet.debug("svckill: Attempting to stop service '#{svc}'")
 
@@ -219,9 +230,9 @@ Puppet::Type.type(:svckill).provide(:kill) do
         begin
           @running_services[svc][:provider].send 'stop'
         rescue Puppet::Error => e
-          Puppet.err("svckill: Failed to stop service '#{svc}'")
+          @results[:stopped][:failed] << svc
         else
-          Puppet.notice("svckill: Stopped service '#{svc}'")
+          @results[:stopped][:passed] << svc
         end
       end
 
@@ -229,11 +240,15 @@ Puppet::Type.type(:svckill).provide(:kill) do
         begin
           @running_services[svc][:provider].send 'disable'
         rescue Puppet::Error => e
-          Puppet.err("svckill: Failed to disable service '#{svc}'")
+          @results[:disabled][:failed] << svc
         else
-          Puppet.notice("svckill: Disabled service '#{svc}'")
+          @results[:disabled][:passed] << svc
         end
       end
     end
+  end
+
+  def results
+    return @results
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,7 +58,8 @@
 #
 class svckill (
   $ignore = [],
-  $ignore_files = []
+  $ignore_files = [],
+  $verbose = true
 ){
   validate_array($ignore)
   validate_array($ignore_files)
@@ -75,6 +76,7 @@ class svckill (
 
   svckill { 'svckill':
     ignore      => $ignore,
-    ignorefiles => flatten([$ignore_files,$default_ignore])
+    ignorefiles => flatten([$ignore_files,$default_ignore]),
+    verbose     => $verbose
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-svckill",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author":  "simp",
   "summary": "Disables all services that are not controlled by Puppet.",
   "license": "Apache-2.0",

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -8,7 +8,7 @@ describe 'Kill Unmanaged Services' do
       it 'should not kill the network' do
         result = apply_manifest_on(host,'include "svckill"', :catch_failures => true).stdout
 
-        expect(result).to_not match(/Stopped.*'network/)
+        expect(result).to_not match(/stopped.*'network/)
       end
 
       it 'should kill Dnsmasq unless declared in a manifest' do
@@ -16,7 +16,7 @@ describe 'Kill Unmanaged Services' do
         on(host, 'puppet resource service dnsmasq ensure=running')
         result = apply_manifest_on(host, 'include "svckill"', :catch_failures => true).stdout
 
-        expect(result).to match(/Stopped.*'dnsmasq/)
+        expect(result).to match(/stopped.*'dnsmasq/)
       end
 
       it 'should not kill Dnsmasq if declared in a manifest' do
@@ -29,7 +29,7 @@ describe 'Kill Unmanaged Services' do
 
         result = apply_manifest_on(host, manifest, :catch_failures => true).stdout
 
-        expect(result).to_not match(/Stopped.*'dnsmasq/)
+        expect(result).to_not match(/stopped.*'dnsmasq/)
       end
     end
 
@@ -46,7 +46,7 @@ describe 'Kill Unmanaged Services' do
         on(host, 'puppet resource service dnsmasq ensure=running')
         result = apply_manifest_on(host, manifest, :catch_failures => true).stdout
 
-        expect(result).to_not match(/Stopped.*'dnsmasq/)
+        expect(result).to_not match(/stopped.*'dnsmasq/)
       end
     end
 
@@ -66,7 +66,7 @@ describe 'Kill Unmanaged Services' do
         on(host, 'puppet resource service dnsmasq ensure=running')
         result = apply_manifest_on(host, manifest, :catch_failures => true).stdout
 
-        expect(result).to_not match(/Stopped.*'dnsmasq/)
+        expect(result).to_not match(/stopped.*'dnsmasq/)
       end
     end
   end


### PR DESCRIPTION
The svckill type has been updated to properly output the results of the
run using the 'to_s' method in the type.

The results should now all properly be accessible via PuppetDB.

SIMP-910 #close

Change-Id: I41f77113f94c274a91e3825be0e42f86a907724b