### PR TITLE
(SIMP-1167) Do not include svckill in ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 dist
 /pkg
 /spec/fixtures
+/spec/rp_env
 !/spec/hieradata/default.yaml
 !/spec/fixtures/site.pp
 /.rspec_system

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,5 +2,3 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-80chars-check
---no-trailing_comma-check
---no-empty_string-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: ruby
-sudo: false
+sudo: true
 cache: bundler
 before_script:
   - bundle

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,41 @@
+* Tue Jun 21 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.1.2-0
+- Ensure that calling '::svckill::ignore' does not include '::svckill' by
+  default.
+
+* Tue Apr 12 2016 Kendall Moore <kendall.moore@onyxpoint.com> - 1.1.1-0
+- Updated custom type to remove deprecation warning
+
+* Thu Mar 10 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.1.0-0
+- Added a 'verbose' option to svckill which will enumerate all actions on
+  services if enabled.
+- Ensure that all relevant messages are passed back via the 'to_s' method so
+  that PuppetDB can obtain a full report.
+
+* Wed Feb 24 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 1.0.0-6
+- Minor linting fixes
+
+* Tue Nov 10 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 1.0.0-5
+- migration to simplib and simpcat (lib/ only)
+
+* Fri Jan 16 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.0-4
+- Changed puppet-server requirement to puppet
+
+* Thu Aug 28 2014 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.0-3
+- Fixed a long-standing bug where failing to stop a service would
+  prevent svckill from disabling it.
+- Added prefdm to the list of services to never kill.
+- Updated to not kill services that have definitions in puppet that
+  are aliased in systemd.
+
+* Thu Jun 19 2014 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.0-2
+- Added support for systemd
+- Added support for regex ignore statements
+- Had to force the service provider to 'redhat' if it fell back to
+  'init' otherwise the startup scripts wouldn't be called
+
+* Fri May 09 2014 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.0-1
+- Add 'rc' to the svckill list so that weird race conditions don't
+  render an Upstart-based system unbootable.
+
+* Wed Apr 16 2014 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.0-0
+- First release of svckill as its own module.

--- a/Gemfile
+++ b/Gemfile
@@ -20,9 +20,6 @@ group :test do
   gem "metadata-json-lint"
   gem "simp-rspec-puppet-facts", "~> 1.3"
 
-  gem 'puppet-lint-empty_string-check',   :require => false
-  gem 'puppet-lint-trailing_comma-check', :require => false
-
 
   # simp-rake-helpers does not suport puppet 2.7.X
   if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
@@ -50,6 +47,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'vagrant-wrapper'
   gem 'simp-beaker-helpers', '>= 1.0.5'
 end

--- a/build/pupmod-svckill.spec
+++ b/build/pupmod-svckill.spec
@@ -1,91 +1,291 @@
-Summary: Svckill Puppet Module
-Name: pupmod-svckill
-Version: 1.1.1
-Release: 0
-License: Apache License, Version 2.0
-Group: Applications/System
-Source: %{name}-%{version}-%{release}.tar.gz
-Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
-Requires: puppet >= 3.3.0
-Buildarch: noarch
-Requires: simp-bootstrap >= 4.2.0
-Obsoletes: pupmod-timezone >= 0.0.1
-Obsoletes: pupmod-svckill-test >= 0.0.1
+%{lua:
 
-Prefix: %{_sysconfdir}/puppet/environments/simp/modules
+--
+-- When you build you must to pass this along so that we know how
+-- to get the preliminary information.
+-- This directory should hold the following items:
+--   * 'build' directory
+--   * 'CHANGELOG' <- The RPM formatted Changelog
+--   * 'metadata.json'
+--
+-- Example:
+--   rpmbuild -D 'pup_module_info_dir /home/user/project/puppet_module' -ba SPECS/specfile.spec
+--
+
+src_dir = rpm.expand('%{pup_module_info_dir}')
+if string.match(src_dir, '^%%') then
+  src_dir = './'
+end
+
+-- These UNKNOWN entries should break the build if something bad happens
+
+module_name = "UNKNOWN"
+module_version = "UNKNOWN"
+module_license = "UNKNOWN"
+
+-- Default to 0
+module_release = '0'
+
+}
+
+%{lua:
+-- Pull the Relevant Metadata out of the Puppet module metadata.json.
+
+metadata = ''
+metadata_file = io.open(src_dir .. "/metadata.json","r")
+if metadata_file then
+  metadata = metadata_file:read("*all")
+end
+
+-- This starts as an empty string so that we can build it later
+module_requires = ''
+
+}
+
+%{lua:
+
+-- Get the Module Name and put it in the correct format
+
+local name_match = string.match(metadata, '"name":%s+"(.-)"%s*,')
+
+if name_match then
+  local i = 0
+  for str in string.gmatch(name_match,'[^-]+') do
+    if i ~= 0 then
+      if i == 1 then
+        module_name = str
+      else
+        module_name = (module_name .. '-' .. str)
+      end
+    end
+
+    i = i+1
+  end
+end
+
+}
+
+%{lua:
+
+-- Get the Module Version
+-- This will not be processed at all
+
+local version_match = string.match(metadata, '"version":%s+"(.-)"%s*,')
+
+if version_match then
+  module_version = version_match
+end
+
+}
+
+%{lua:
+
+-- Get the Module License
+-- This will not be processed at all
+
+local license_match = string.match(metadata, '"license":%s+"(.-)"%s*,')
+
+if license_match then
+  module_license = license_match
+end
+
+}
+
+%{lua:
+
+-- Get the Module Summary
+-- This will not be processed at all
+
+local summary_match = string.match(metadata, '"summary":%s+"(.-)"%s*,')
+
+if summary_match then
+  module_summary = summary_match
+end
+
+}
+
+%{lua:
+
+-- Get the Module Source line for the URL string
+-- This will not be processed at all
+
+local source_match = string.match(metadata, '"source":%s+"(.-)"%s*,')
+
+if source_match then
+  module_source = source_match
+end
+
+}
+
+%{lua:
+
+-- Snag the RPM-specific items out of the 'build/rpm_metadata' directory
+
+-- First, the Release Number
+
+local rel_file = io.open(src_dir .. "/build/rpm_metadata/release", "r")
+if rel_file then
+  for line in rel_file:lines() do
+    is_comment = string.match(line, "^%s*#")
+    is_blank = string.match(line, "^%s*$")
+
+    if not (is_comment or is_blank) then
+      module_release = line
+      break
+    end
+  end
+end
+
+}
+
+%{lua:
+
+-- Next, the Requirements
+local req_file = io.open(src_dir .. "/build/rpm_metadata/requires", "r")
+if req_file then
+  for line in req_file:lines() do
+    valid_line = (string.match(line, "^Requires: ") or string.match(line, "^Obsoletes: ") or string.match(line, "^Provides: "))
+
+    if valid_line then
+      module_requires = (module_requires .. "\n" .. line)
+    end
+  end
+end
+}
+
+%define module_name %{lua: print(module_name)}
+%define base_name pupmod-%{module_name}
+
+%{lua:
+-- Determine which Variant we are going to build
+
+local variant = rpm.expand("%{_variant}")
+local variant_version = nil
+
+local foo = ""
+
+local i = 0
+for str in string.gmatch(variant,'[^-]+') do
+  if i == 0 then
+    variant = str
+  elseif i == 1 then
+    variant_version = str
+  else
+    break
+  end
+
+  i = i+1
+end
+
+rpm.define("variant " .. variant)
+
+if variant == "pe" then
+  rpm.define("puppet_user pe-puppet")
+else
+  rpm.define("puppet_user puppet")
+end
+
+if variant == "pe" then
+  if variant_version and ( rpm.vercmp(variant_version,'4') >= 0 ) then
+    rpm.define("_sysconfdir /etc/puppetlabs/code")
+  else
+    rpm.define("_sysconfdir /etc/puppetlabs/puppet")
+  end
+elseif variant == "p4" then
+  rpm.define("_sysconfdir /etc/puppetlabs/code")
+else
+  rpm.define("_sysconfdir /etc/puppet")
+end
+}
+
+Summary:   %{module_name} Puppet Module
+%if 0%{?_variant:1}
+Name:      %{base_name}-%{_variant}
+%else
+Name:      %{base_name}
+%endif
+
+Version:   %{lua: print(module_version)}
+Release:   %{lua: print(module_release)}
+License:   %{lua: print(module_license)}
+Group:     Applications/System
+Source:    %{base_name}-%{version}-%{release}.tar.gz
+URL:       %{lua: print(module_source)}
+BuildRoot: %{_tmppath}/%{base_name}-%{version}-%{release}-buildroot
+BuildArch: noarch
+
+%if "%{variant}" == "pe"
+Requires: pe-puppet
+%else
+Requires: puppet
+%endif
+
+%{lua: print(module_requires)}
+
+Prefix: %{_sysconfdir}/environments/simp/modules
 
 %description
-This Puppet module provides the capability to disable all services on
-a system that are not controlled by Puppet.
-
-Several methods for excluding services from the kill list are
-provided.
+%{lua: print(module_summary)}
 
 %prep
-%setup -q
+%setup -q -n %{base_name}-%{version}
 
 %build
 
 %install
 [ "%{buildroot}" != "/" ] && rm -rf %{buildroot}
 
-mkdir -p %{buildroot}/%{prefix}/svckill
+mkdir -p %{buildroot}/%{prefix}
 
-dirs='files lib manifests templates'
-for dir in $dirs; do
-  test -d $dir && cp -r $dir %{buildroot}/%{prefix}/svckill
-done
+rm -rf .git
+rm -f *.lock
+rm -rf spec/fixtures/modules
+rm -rf dist
+rm -rf junit
+rm -rf log
+
+curdir=`pwd`
+dirname=`basename $curdir`
+cp -r ../$dirname %{buildroot}/%{prefix}/%{module_name}
 
 %clean
 [ "%{buildroot}" != "/" ] && rm -rf %{buildroot}
 
-mkdir -p %{buildroot}/%{prefix}/svckill
+mkdir -p %{buildroot}/%{prefix}
 
 %files
-%defattr(0640,root,puppet,0750)
-%{prefix}/svckill
-
-%post
-#!/bin/sh
-
-%postun
-# Post uninstall stuff
+%defattr(0640,root,%{puppet_user},0750)
+%{prefix}/%{module_name}
 
 %changelog
-* Tue Apr 12 2016 Kendall Moore <kendall.moore@onyxpoint.com> - 1.1.1-0
-- Updated custom type to remove deprecation warning
+%{lua:
+-- Finally, the CHANGELOG
 
-* Thu Mar 10 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.1.0-0
-- Added a 'verbose' option to svckill which will enumerate all actions on
-  services if enabled.
-- Ensure that all relevant messages are passed back via the 'to_s' method so
-  that PuppetDB can obtain a full report.
+-- A default CHANGELOG in case we cannot find a real one
 
-* Wed Feb 24 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 1.0.0-6
-- Minor linting fixes
+default_changelog = [===[
+* $date Auto Changelog <auto@no.body> - $version-$release
+- Latest release of $name
+]===]
 
-* Tue Nov 10 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 1.0.0-5
-- migration to simplib and simpcat (lib/ only)
+default_lookup_table = {
+  date = os.date("%a %b %d %Y"),
+  version = module_version,
+  release = module_release,
+  name = module_name
+}
 
-* Fri Jan 16 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.0-4
-- Changed puppet-server requirement to puppet
+changelog = io.open(src_dir .. "/CHANGELOG","r")
+if changelog then
+  first_line = changelog:read()
+  if string.match(first_line, "^*%s+%a%a%a%s+%a%a%a%s+%d%d?%s+%d%d%d%d%s+.+") then
+    changelog:seek("set",0)
+    print(changelog:read("*all"))
+  else
+    print((default_changelog:gsub('$(%w+)', default_lookup_table)))
+  end
+else
+  print((default_changelog:gsub('$(%w+)', default_lookup_table)))
+end
+}
 
-* Thu Aug 28 2014 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.0-3
-- Fixed a long-standing bug where failing to stop a service would
-  prevent svckill from disabling it.
-- Added prefdm to the list of services to never kill.
-- Updated to not kill services that have definitions in puppet that
-  are aliased in systemd.
-
-* Thu Jun 19 2014 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.0-2
-- Added support for systemd
-- Added support for regex ignore statements
-- Had to force the service provider to 'redhat' if it fell back to
-  'init' otherwise the startup scripts wouldn't be called
-
-* Fri May 09 2014 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.0-1
-- Add 'rc' to the svckill list so that weird race conditions don't
-  render an Upstart-based system unbootable.
-
-* Wed Apr 16 2014 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.0-0
-- First release of svckill as its own module.

--- a/manifests/ignore.pp
+++ b/manifests/ignore.pp
@@ -1,19 +1,11 @@
-#
-# == Define: svckill::ignore
-#
 # Ensure that service $name will not be killed by svckill.
 #
-# == Parameters
+# @param name [String] The name of the service to prevent from being killed.
 #
-# [*name*]
-# Type: String
-#   The name of the service to prevent from being killed.
-#
-# == Authors
-#   * Trevor Vaughan <tvaughan@onyxpoint.com>
+# @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 define svckill::ignore {
-  include 'svckill'
+  include '::svckill::ignore::collector'
 
   concat_fragment { "svckill_ignore+${name}.ignore": content => "${name}\n" }
 }

--- a/manifests/ignore/collector.pp
+++ b/manifests/ignore/collector.pp
@@ -1,0 +1,18 @@
+# Build the default ignore file used by the `svckill::ignore` define.
+#
+# @param default_ignore_file [Absolute Path] The path to the ignore file.
+#
+# @author Trevor Vaughan <tvaughan@onyxpoint.com>
+#
+class svckill::ignore::collector (
+  $default_ignore_file = '/usr/local/etc/svckill.ignore'
+){
+
+  validate_absolute_path($default_ignore_file)
+
+  concat_build { 'svckill_ignore':
+    order  => ['*.ignore'],
+    target => $default_ignore_file,
+    quiet  => true
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,3 @@
-# == Class: svckill
-#
 # Svckill is a system that attempts to run with the security best
 # practice that "No unnecessary services should be running on the
 # system."
@@ -37,24 +35,19 @@
 #   * sysstat
 #   * udev-post
 #
-# == Parameters:
+# @param ignore [Array(String)] A list of services to never kill.
 #
-# [*ignore*]
-# Type: Array of Strings
-# Default: []
-#   A list of services to never kill.
-#
-# [*ignore_files*]
-# Type: Array of Absolute Paths
-# Default: []
-#   A list of files that contain services to never kill, one per line.
-#   You can add your own files here if you wish to use an alternate
-#   ignore list.
-#   The file '/usr/local/etc/svckill.ignore' will always be used but
+# @param ignore_files [Array(Absolute Path)] A list of files that contain
+#   services to never kill, one per line.  You can add your own files here if
+#   you wish to use an alternate ignore list. The file specified in
+#   `::svckill::ignore::collector::default_ignore_file` will always be used but
 #   is fully managed by puppet.
 #
-# == Authors:
-#   * Trevor Vaughan <tvaughan@onyxpoint.com>
+# @parm verbose [Boolean] If set, svckill should report on exactly what it
+#   attempted to kill. If false, it will only report on the number of services
+#   that it attempted to kill.
+#
+# @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class svckill (
   $ignore = [],
@@ -65,18 +58,15 @@ class svckill (
   validate_array($ignore_files)
   if !empty($ignore_files) { validate_re_array($ignore_files,'^/') }
 
-  $default_ignore = '/usr/local/etc/svckill.ignore'
-
-  concat_build { 'svckill_ignore':
-    order  => ['*.ignore'],
-    target => $default_ignore,
-    quiet  => true,
-    before => Svckill['svckill']
-  }
+  include '::svckill::ignore::collector'
 
   svckill { 'svckill':
     ignore      => $ignore,
-    ignorefiles => flatten([$ignore_files,$default_ignore]),
-    verbose     => $verbose
+    ignorefiles => flatten([
+      $ignore_files,
+      $::svckill::ignore::collector::default_ignore_file
+    ]),
+    verbose     => $verbose,
+    require     => Class['svckill::ignore::collector']
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-svckill",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author":  "simp",
   "summary": "Disables all services that are not controlled by Puppet.",
   "license": "Apache-2.0",

--- a/spec/defines/ignore_spec.rb
+++ b/spec/defines/ignore_spec.rb
@@ -6,4 +6,6 @@ describe 'svckill::ignore' do
 
   it { is_expected.to compile.with_all_deps }
   it { is_expected.to create_concat_fragment("svckill_ignore+#{title}.ignore").with_content("#{title}\n") }
+  it { is_expected.to create_concat_build('svckill_ignore') }
+  it { is_expected.to_not create_svckill('svckill') }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,7 +45,7 @@ EOM
 # end
 #
 def set_environment(environment = :production)
-    RSpec.configure { |c| c.default_facts['environment'] = environment.to_s }
+  RSpec.configure { |c| c.default_facts['environment'] = environment.to_s }
 end
 
 # This can be used from inside your spec tests to load custom hieradata within
@@ -67,7 +67,7 @@ end
 #
 # Note: Any colons (:) are replaced with underscores (_) in the class name.
 def set_hieradata(hieradata)
-    RSpec.configure { |c| c.default_facts['custom_hiera'] = hieradata }
+  RSpec.configure { |c| c.default_facts['custom_hiera'] = hieradata }
 end
 
 if not File.directory?(File.join(fixture_path,'hieradata')) then


### PR DESCRIPTION
Calling 'svckill::ignore' should not activate 'svckill' by default. This
is meant to be a safety mechanism and including 'svckill' is definitely
not safe on a system that isn't expecting it.

SIMP-1167 #comment Found issue during testing
SIMP-1174 #close
