### PR TITLE
(SIMP-1450) Update to use new 'simpcat'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-0
+- Updated to use the version of 'simpcat' that does not conflict with
+  'puppetlabs/concat'.
+
 * Thu Jul 07 2016 Nick Markowski <nmarkowski@keywcorp.com> - 1.1.3-0
 - Added missing requires file and updated module to auto-generate
   lua spec file.

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,1 +1,2 @@
+Requires: pupmod-simp-simpcat >= 6.0.0
 Obsoletes: pupmod-svckill-test >= 0.0.1

--- a/lib/puppet/type/svckill.rb
+++ b/lib/puppet/type/svckill.rb
@@ -154,7 +154,7 @@ Puppet::Type.newtype(:svckill) do
     [self[:ignorefiles]]
   end
 
-  autorequire(:concat_build) do
+  autorequire(:simpcat_build) do
     [self[:ignorefiles]]
   end
 end

--- a/manifests/ignore.pp
+++ b/manifests/ignore.pp
@@ -7,5 +7,5 @@
 define svckill::ignore {
   include '::svckill::ignore::collector'
 
-  concat_fragment { "svckill_ignore+${name}.ignore": content => "${name}\n" }
+  simpcat_fragment { "svckill_ignore+${name}.ignore": content => "${name}\n" }
 }

--- a/manifests/ignore/collector.pp
+++ b/manifests/ignore/collector.pp
@@ -10,7 +10,7 @@ class svckill::ignore::collector (
 
   validate_absolute_path($default_ignore_file)
 
-  concat_build { 'svckill_ignore':
+  simpcat_build { 'svckill_ignore':
     order  => ['*.ignore'],
     target => $default_ignore_file,
     quiet  => true

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-svckill",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "author":  "simp",
   "summary": "Disables all services that are not controlled by Puppet.",
   "license": "Apache-2.0",
@@ -11,7 +11,7 @@
   "dependencies": [
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp/simplib",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'svckill' do
 
   it { is_expected.to compile.with_all_deps }
-  it { is_expected.to create_concat_build('svckill_ignore') }
+  it { is_expected.to create_simpcat_build('svckill_ignore') }
   it { is_expected.to create_svckill('svckill') }
 
 end

--- a/spec/defines/ignore_spec.rb
+++ b/spec/defines/ignore_spec.rb
@@ -5,7 +5,7 @@ describe 'svckill::ignore' do
   let(:title) { 'test' }
 
   it { is_expected.to compile.with_all_deps }
-  it { is_expected.to create_concat_fragment("svckill_ignore+#{title}.ignore").with_content("#{title}\n") }
-  it { is_expected.to create_concat_build('svckill_ignore') }
+  it { is_expected.to create_simpcat_fragment("svckill_ignore+#{title}.ignore").with_content("#{title}\n") }
+  it { is_expected.to create_simpcat_build('svckill_ignore') }
   it { is_expected.to_not create_svckill('svckill') }
 end


### PR DESCRIPTION
Updated to use the version of 'simpcat' that does not conflict with
'puppetlabs/concat'.

SIMP-1450 #comment Update to use deconflicted 'simpcat'
SIMP-843 #comment Deconflicted 'svckill'
