### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,1 +1,5 @@
 Obsoletes: pupmod-svckill-test >= 0.0.1
+Requires: pupmod-simp-simpcat < 6.0.0-0
+Requires: pupmod-simp-simpcat >= 5.0.1-0
+Requires: pupmod-simp-simplib < 2.0.0-0
+Requires: pupmod-simp-simplib >= 1.3.1-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,21 +1,24 @@
 {
-  "name":    "simp-svckill",
-  "version": "1.1.3",
-  "author":  "simp",
+  "name": "simp-svckill",
+  "version": "1.1.4",
+  "author": "simp",
   "summary": "Disables all services that are not controlled by Puppet.",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-svckill",
+  "source": "https://github.com/simp/pupmod-simp-svckill",
   "project_page": "https://github.com/simp/pupmod-simp-svckill",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "svckill" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "svckill"
+  ],
   "dependencies": [
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 5.0.1 < 6.0.0"
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.3.1 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-svckill`
SIMP-1599 #close