### PR TITLE
(SIMP-2895) Change the svckill default to 'warning'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Thu Mar 23 2017 Trevor Vaughan - 3.2.0-0
+- Enabled the new, kinder, svckill by setting the default mode to 'warning'
+- Added a `svckill::enable` parameter to be able to disable svckill from Hiera
+  easily
+
 * Fri Mar 17 2017 Nick Miller, Ryan Russell-Yates, Liz Nemsick - 3.1.1-0
 - Add acceptance test for symlinked services
 - Flesh out README

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ services not listed in your manifests or the exclusion file. If set to
 'warning', will only report on what would happen without actually making the
 changes to the system.
   * Valid Options: enforcing and warning.
-  * Default: `enforcing`.
+  * Default: `warning`.
 
 ### `svckill` Class
 
@@ -221,7 +221,7 @@ services not listed in your manifests or the exclusion file. If set to
 'warning', will only report on what would happen without actually making the
 changes to the system.
   * Valid Options: enforcing and warning.
-  * Default:`enforcing`.
+  * Default:`warning`.
 
 ### `svckill::ignore`
 

--- a/lib/puppet/type/svckill.rb
+++ b/lib/puppet/type/svckill.rb
@@ -93,10 +93,10 @@ Puppet::Type.newtype(:svckill) do
       If set to 'warning', will only report on what would happen
       without actually making the changes to the system.
 
-      Default: 'enforcing'
+      Default: 'warning'
     EOM
 
-    defaultto 'enforcing'
+    defaultto 'warning'
 
     validate do |value|
       unless ['enforcing','warning'].include?("#{value}")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,9 @@
 #   * sysstat
 #   * udev-post
 #
+# @param enable
+#   Enable svckill on the system
+#
 # @param ignore
 #   A list of services to never kill
 #
@@ -68,20 +71,25 @@
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class svckill (
-  Array[String]               $ignore       = [],
+  Boolean                     $enable          = true,
+  Array[String]               $ignore          = [],
   Array[String]               $ignore_defaults = [],
-  Array[Stdlib::Absolutepath] $ignore_files = [],
-  Enum['enforcing','warning'] $mode         = 'enforcing',
-  Boolean                     $verbose      = true,
+  Array[Stdlib::Absolutepath] $ignore_files    = [],
+  Enum['enforcing','warning'] $mode            = 'warning',
+  Boolean                     $verbose         = true,
 ){
-  include '::svckill::ignore::collector'
-  $combined_ignore_list = $ignore + $ignore_defaults
-  $flattened_ignore_files = flatten([$ignore_files, $::svckill::ignore::collector::default_ignore_file])
-  svckill { 'svckill':
-    ignore      => $combined_ignore_list,
-    ignorefiles => $flattened_ignore_files,
-    verbose     => $verbose,
-    mode        => $mode,
-    require     => Class['svckill::ignore::collector']
+  if $enable {
+    include '::svckill::ignore::collector'
+
+    $combined_ignore_list = $ignore + $ignore_defaults
+    $flattened_ignore_files = flatten([$ignore_files, $::svckill::ignore::collector::default_ignore_file])
+
+    svckill { 'svckill':
+      ignore      => $combined_ignore_list,
+      ignorefiles => $flattened_ignore_files,
+      verbose     => $verbose,
+      mode        => $mode,
+      require     => Class['svckill::ignore::collector']
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-svckill",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "author": "SIMP Team",
   "summary": "Disables all services that are not controlled by Puppet.",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -10,7 +10,14 @@ describe 'svckill' do
         it { is_expected.to create_class('svckill') }
 
         it { is_expected.to create_concat('/usr/local/etc/svckill.ignore') }
-        it { is_expected.to create_svckill('svckill').with_mode('enforcing') }
+        it { is_expected.to create_svckill('svckill').with_mode('warning') }
+
+        context 'if disabling svckill' do
+          let(:params) {{ :enable => false }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to_not create_svckill('svckill') }
+        end
       end
     end
   end


### PR DESCRIPTION
By far, the most infuriating feature of SIMP, svckill is now being set
to 'warning' by default so that users are not surprised when their
services stop working across the board.

This will help users understand exactly what is being done on their
system and the impact of enabling this capability.

Also added a parameter, `svckill::enable` to allow users to easily
enable or disable svckill completely without needing to alter Puppet
code.

SIMP-2895 #close