### PR TITLE
(SIMP-52) Fix systemd alias check

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Wed Apr 19 2017 Nick Markowski <nmarkowski@keywcorp.com> - 3.2.1-0
+- In the service kill provider, not all services queried by 'Name'
+  with systemctl would return a name.  That caused a break in symlink
+  logic, rendering a majority of aliases to remain undetected.  Error
+  detection has been added and the symlink logic has been re-worked.
+
 * Thu Mar 23 2017 Trevor Vaughan - 3.2.0-0
 - Enabled the new, kinder, svckill by setting the default mode to 'warning'
 - Added a `svckill::enable` parameter to be able to disable svckill from Hiera
@@ -11,7 +17,7 @@
 
 * Fri Dec 30 2016 Dylan Cochran <dylan.cochran@onyxpoint.com> - 3.1.0-0
 - Use hiera moduledata instead of a hard coded array
-- Add ignore for ^pe-.*  
+- Add ignore for ^pe-.*
 
 * Sat Dec 24 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.0.0-0
 - Updated to use the Puppet Concat module

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ end
 
 group :system_tests do
   # This patch is required to fix Beaker's broken `aio` handling
-  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-931-2.51.0'
+  gem 'beaker'
   gem 'beaker-rspec'
   gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-svckill",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "author": "SIMP Team",
   "summary": "Disables all services that are not controlled by Puppet.",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -4,10 +4,16 @@ test_name 'svckill'
 
 describe 'Kill Unmanaged Services' do
   hosts.each do |host|
-    context 'default parameters' do
+    hieradata = <<-EOM
+---
+
+svckill::mode: 'enforcing'
+EOM
+    context 'with mode=enforcing' do
+      set_hieradata_on(host, hieradata, 'default')
+
       it 'should not kill the network' do
         result = apply_manifest_on(host,'include "svckill"', :catch_failures => true).stdout
-
         expect(result).to_not match(/stopped.*'network/)
       end
 
@@ -15,7 +21,6 @@ describe 'Kill Unmanaged Services' do
         on(host, 'puppet resource package dnsmasq ensure=installed')
         on(host, 'puppet resource service dnsmasq ensure=running')
         result = apply_manifest_on(host, 'include "svckill"', :catch_failures => true).stdout
-
         expect(result).to match(/stopped.*'dnsmasq/)
       end
 
@@ -28,7 +33,6 @@ describe 'Kill Unmanaged Services' do
         EOS
 
         result = apply_manifest_on(host, manifest, :catch_failures => true).stdout
-
         expect(result).to_not match(/stopped.*'dnsmasq/)
       end
     end
@@ -37,7 +41,8 @@ describe 'Kill Unmanaged Services' do
       it 'should not kill Dnsmasq' do
         manifest = <<-EOS
           class { 'svckill':
-            ignore => ['dnsmasq']
+            ignore => ['dnsmasq'],
+            mode   => 'enforcing'
           }
 
           package { 'dnsmasq': ensure => 'present' }
@@ -45,7 +50,6 @@ describe 'Kill Unmanaged Services' do
 
         on(host, 'puppet resource service dnsmasq ensure=running')
         result = apply_manifest_on(host, manifest, :catch_failures => true).stdout
-
         expect(result).to_not match(/stopped.*'dnsmasq/)
       end
     end
@@ -56,7 +60,8 @@ describe 'Kill Unmanaged Services' do
 
         manifest = <<-EOS
           class { 'svckill':
-            ignore_files => ['#{ignore_file}']
+            ignore_files => ['#{ignore_file}'],
+            mode         => 'enforcing'
           }
 
           package { 'dnsmasq': ensure => 'present' }
@@ -65,7 +70,6 @@ describe 'Kill Unmanaged Services' do
         create_remote_file(host, ignore_file, "dnsmasq\n")
         on(host, 'puppet resource service dnsmasq ensure=running')
         result = apply_manifest_on(host, manifest, :catch_failures => true).stdout
-
         expect(result).to_not match(/stopped.*'dnsmasq/)
       end
     end
@@ -78,7 +82,6 @@ describe 'Kill Unmanaged Services' do
 
         on(host, 'puppet resource service dnsmasq ensure=running')
         result = apply_manifest_on(host, manifest, :catch_failures => true).stdout
-
         expect(result).to_not match(/stopped.*'dnsmasq/)
       end
     end

--- a/spec/acceptance/suites/default/01_symlinked_services_spec.rb
+++ b/spec/acceptance/suites/default/01_symlinked_services_spec.rb
@@ -12,28 +12,31 @@ describe 'not kill services which are symlinked to other services' do
       let(:manifest) {
         <<-EOF
         class { 'svckill':
-          verbose => true
+          verbose => true,
+          mode    => 'enforcing'
         }
         service { 'nfs-server': }
         EOF
       }
+
       it 'should set up an essential service' do
         # dnsmasq is sometimes still running and triggers svckill
         on host, 'puppet resource service dnsmasq ensure=stopped'
         on host, 'puppet resource package nfs ensure=latest'
         on host, 'puppet resource service nfs ensure=running'
       end
+
       it 'should run puppet and not kill the application' do
         result = apply_manifest_on(host, manifest, :catch_failures => true).stdout
         (require 'pry'; binding.pry) if ENV.fetch('BEAKER_pry','').chomp == 'svckill'
 
-        # svckill/service/systemctl already seems smart enough to treat
-        # symlinked services the same as their targets
+        # In el7, nfs.service is an alias of nfs-server.service and should not be
+        # stopped or disabled
         expect(result).to_not match(/stopped.*'nfs-server/)
-        expect(result).to_not match(/stopped.*'nfs/)
-        ### # gssproxy is not symlinked to nfs.service, but will be stopped
-        ### # nfs.service -> auth-rpcgss-module.service -> gssproxy.service
-        ### expect(result).to_not match(/stopped.*'gssproxy/)
+        expect(result).to_not match(/stopped.*'nfs.service'/)
+        expect(result).to_not match(/disabled.*'nfs.service'/)
+        # Without kerberos, this should not be running
+        expect(result).to match(/stopped.*'gssproxy.service'/)
       end
     end
 
@@ -41,25 +44,25 @@ describe 'not kill services which are symlinked to other services' do
       let(:manifest) {
         <<-EOF
         class { 'svckill':
-          verbose => true
+          verbose => true,
+          mode    => 'enforcing'
         }
         service { 'gdm': }
         EOF
       }
+
       it 'should set up an essential service' do
         # dnsmasq is sometimes still running and triggers svckill
         on host, 'puppet resource service dnsmasq ensure=stopped'
-
         on host, 'yum install -y @x11 gdm gnome-shell gnome-session-xsession'
         on host, 'systemctl enable gdm.service --now'
-
         on host, 'systemctl set-default graphical.target'
         on host, 'systemctl isolate graphical.target'
       end
+
       it 'should run puppet and not kill the application' do
         result = apply_manifest_on(host, manifest, :catch_failures => true).stdout
         (require 'pry'; binding.pry) if ENV.fetch('BEAKER_pry','').chomp == 'svckill'
-
         expect(result).to_not match(/stopped.*'gdm/)
         expect(result).to_not match(/stopped.*'display-manager/)
       end


### PR DESCRIPTION
- In the service kill provider, not all services queried by 'Name'
  with systemctl would return a name.  That caused a break in symlink
  logic, rendering a majority of aliases to remain undetected.  Error
  detection has been added and the symlink logic has been re-worked.

SIMP-52 #comment updated svckill
SIMP-3081 #close