### PR TITLE
(SIMP-2951) svckill::mode: enforcing causes insync failure

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Jun 23 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.2.1-0
+- Fix bug whereby svckill provider's insync_values? emits
+  'Unknown failure' message during normal operation.
+
 * Fri Jun 09 2017 Nick Markowski <nmarkowski@keywcorp.com> - 3.2.1-0
 - Implemented simplib::knockout on the ignore list so users can
   remove items in the default list via hiera.

--- a/lib/puppet/provider/svckill/kill.rb
+++ b/lib/puppet/provider/svckill/kill.rb
@@ -163,7 +163,7 @@ Puppet::Type.type(:svckill).provide(:kill) do
       return true
     end
 
-    return @running_services.empty?
+    return @running_services.nil? || @running_services.empty?
   end
 
   def mode=(should)


### PR DESCRIPTION
Was able to reliably recreate with SIMP 6 for CentOS 6.8 vbox.
Added debug logic to puppet/property.rb insync_values?() exception handling code to track down the problem.

SIMP-2951 #close