### PR TITLE
(SIMP-3155) svckill: Unit tests fail when run in docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ cache: bundler
 before_script:
   - bundle update
 bundler_args: --without development system_tests --path .vendor
-before_install: rm Gemfile.lock || true
+before_install: 
+  - rm Gemfile.lock || true
+  - rvm @global do gem uninstall bundler -a -x
+  - rvm @global do gem install bundler -v '~> 1.14.0'
 script:
   - bundle exec rake test
 notifications:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Aug 01 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.2.2-0
+- Tweak spec tests so will run in docker containers
+
 * Fri Jun 23 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.2.1-0
 - Fix bug whereby svckill provider's insync_values? emits
   'Unknown failure' message during normal operation.

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ group :test do
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 3.5')
+  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 4.0')
 end
 
 group :development do

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-svckill",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "author": "SIMP Team",
   "summary": "Disables all services that are not controlled by Puppet.",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -6,6 +6,15 @@ describe 'svckill' do
       let(:facts) { os_facts }
 
       context "on #{os}" do
+        before :each do
+          # In some test environments (docker containers), systemctl
+          # is detected to be present but is not available to this
+          # process.  So, to prevent systemctl commands from being
+          # called by the svckill provider, mock the method the
+          # provider uses to determine if systemctl is available.
+          Puppet::Util.stubs(:which).with('systemctl').returns(nil)
+        end
+
         context 'with default parameters' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_class('svckill') }


### PR DESCRIPTION
Mock Puppet::Util::which('systemctl') call in init_spec.rb,
so systemctl will not be called on systems on which it appears
to exist but is not accessible by the test program.
Update to latest facter and simp development gems.
Pin version of bundler in travis.

SIMP-3155 #close