### PR TITLE
(SIMP-3613) svckill: Update to concat 3.0.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,14 +1,8 @@
 ---
 fixtures:
   repositories:
-    concat:
-      repo: "https://github.com/simp/puppetlabs-concat"
-      tag: 2.2.0
-    simplib:
-      repo: "https://github.com/simp/pupmod-simp-simplib"
-      tag: 3.1.0
-    stdlib:
-      repo: https://github.com/simp/puppetlabs-stdlib
-      tag: 4.13.1
+    concat: "https://github.com/simp/puppetlabs-concat"
+    simplib: "https://github.com/simp/pupmod-simp-simplib"
+    stdlib: " https://github.com/simp/puppetlabs-stdlib"
   symlinks:
     svckill: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Aug 18 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.2.3-0
+- Update concat version in metadata.json & build/rpm_metadata/requires
+
 * Tue Aug 01 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.2.2-0
 - Tweak spec tests so will run in docker containers
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,5 @@
 Obsoletes: pupmod-svckill-test >= 0.0.1
-Requires: pupmod-puppetlabs-concat < 3.0.0-0
+Requires: pupmod-puppetlabs-concat < 4.0.0-0
 Requires: pupmod-puppetlabs-concat >= 2.2.0-0
 Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
 Requires: pupmod-puppetlabs-stdlib >= 4.13.1-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-svckill",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "author": "SIMP Team",
   "summary": "Disables all services that are not controlled by Puppet.",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.2.0 < 3.0.0"
+      "version_requirement": ">= 2.2.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
- concat 3.0.0 is fully backward compatible with 2.x.
- Remove 'tag:' in .fixtures.yml, as that doesn't work. (Has to
  be a 'ref:'.)  Removal is identical to existing behavior (tag:
  is ignored), which is to test against master.