### PR TITLE
(SIMP-5387) Update svckill  whitelist for EL 7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Oct 02 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 3.3.0-0
+- Added Redhat 7.5 services to default service ignore list.
+
 * Mon Sep 10 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 3.3.0-0
 - Update Hiera 4 to Hiera 5
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ ignore list will be disabled and turned off on a system. The following are
 exceptions:
 
 ```
-    The following services are hard coded to never be killed by svckill:
+    The following services are hard coded to never be killed by svckill
+    (see the module's hiera data, setting svckill::ignore_defaults, for a
+     comprehensive list):
       * amtu
       * blk-availability
       * crond

--- a/data/family_release/RedHat-7.yaml
+++ b/data/family_release/RedHat-7.yaml
@@ -16,5 +16,12 @@ svckill::ignore_defaults:
   - kdump
   - tuned
   - rsyslog
+  - rhel-autorelabel-mark
+  - rhel-autorelabel
+  - rhel-configure
   - rhel-dmesg
+  - rhel-import-state
+  - rhel-loadmodules
+  - rhel-readonly
+  - selinuxfsrelabel
   - ^autovt@.*

--- a/spec/acceptance/suites/default/01_symlinked_services_spec.rb
+++ b/spec/acceptance/suites/default/01_symlinked_services_spec.rb
@@ -6,7 +6,9 @@ test_name 'svckill'
 describe 'not kill services which are symlinked to other services' do
   hosts.each do |host|
     # This issue only exists on systemd systems
-    next if JSON.load(fact_on(host, 'os', { :json => nil }))['os']['release']['major'] == '6'
+ #   next if JSON.load(fact_on(host, 'os', { :json => nil }))['os']['release']['major'] == '6'
+    os_result = fact_on(host, 'os')
+    next if os_result['release']['major'] == '6'
 
     context 'nfs and nfs-server' do
       let(:manifest) {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -20,10 +20,17 @@ describe 'svckill' do
           it { is_expected.to create_class('svckill') }
 
           it { is_expected.to create_concat('/usr/local/etc/svckill.ignore') }
-          it { is_expected.to create_svckill('svckill').with({
-            :mode => 'warning',
-            :ignore => ["goferd", "^systemd-nspawn@.*", "systemd-bootchart", "systemd-readahead-collect", "systemd-readahead-drop", "systemd-readahead-replay", "NetworkManager", "NetworkManager-dispatcher", "NetworkManager-wait-online", "microcode", "lvm2-lvmetad", "lvm2-lvmpolld", "lvm2-monitor", "kdump", "tuned", "rsyslog", "rhel-dmesg", "^autovt@.*", "amtu", "blk-availability", "dbus.*", "getty.*", "gpm", "haldaemon", "irqbalance", "killall", "libvirt-guests", "mcstrans", "mdmonitor", "messagebus", "prefdm", "netcf-transaction", "netfs", "netlabel", "network", "ntpdate", "portreserve", "restorecond", "sandbox", "sysstat", "udev-post", "krb524", "mdmpd", "readahead_later", "lm_sensors", "kudzu", "auditd", "puppet", "puppetmaster", "crond", "sshd", "iptables", "ip6tables", "ebtables", "rc", "^pe-.*", "simp_client_bootstrap"],
-          })}
+          it {
+            if facts[:os][:release][:major].to_s < '7'
+              expected_ignore_list = ["goferd", "^systemd-nspawn@.*", "systemd-bootchart", "systemd-readahead-collect", "systemd-readahead-drop", "systemd-readahead-replay", "NetworkManager", "NetworkManager-dispatcher", "NetworkManager-wait-online", "microcode", "lvm2-lvmetad", "lvm2-lvmpolld", "lvm2-monitor", "kdump", "tuned", "rsyslog", "rhel-dmesg", "^autovt@.*", "amtu", "blk-availability", "dbus.*", "getty.*", "gpm", "haldaemon", "irqbalance", "killall", "libvirt-guests", "mcstrans", "mdmonitor", "messagebus", "prefdm", "netcf-transaction", "netfs", "netlabel", "network", "ntpdate", "portreserve", "restorecond", "sandbox", "sysstat", "udev-post", "krb524", "mdmpd", "readahead_later", "lm_sensors", "kudzu", "auditd", "puppet", "puppetmaster", "crond","sshd", "iptables", "ip6tables", "ebtables", "rc", "^pe-.*", "simp_client_bootstrap"]
+            else
+              expected_ignore_list = ["goferd", "^systemd-nspawn@.*", "systemd-bootchart", "systemd-readahead-collect", "systemd-readahead-drop", "systemd-readahead-replay", "NetworkManager", "NetworkManager-dispatcher", "NetworkManager-wait-online", "microcode", "lvm2-lvmetad", "lvm2-lvmpolld", "lvm2-monitor", "kdump", "tuned", "rsyslog", "rhel-autorelabel-mark", "rhel-autorelabel", "rhel-configure","rhel-dmesg","rhel-import-state","rhel-loadmodules","rhel-readonly","selinuxfsrelabel", "^autovt@.*", "amtu", "blk-availability", "dbus.*", "getty.*", "gpm", "haldaemon", "irqbalance", "killall", "libvirt-guests", "mcstrans", "mdmonitor", "messagebus", "prefdm", "netcf-transaction", "netfs", "netlabel", "network", "ntpdate", "portreserve", "restorecond", "sandbox", "sysstat", "udev-post", "krb524", "mdmpd", "readahead_later", "lm_sensors", "kudzu", "auditd", "puppet", "puppetmaster", "crond","sshd", "iptables", "ip6tables", "ebtables", "rc", "^pe-.*", "simp_client_bootstrap"] 
+            end
+            is_expected.to create_svckill('svckill').with({
+              :mode => 'warning',
+              :ignore => expected_ignore_list, 
+            })
+          }
 
           context 'if disabling svckill' do
             let(:params) {{ :enable => false }}
@@ -37,11 +44,19 @@ describe 'svckill' do
           let(:hieradata) { 'no_sshd' }
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_class('svckill') }
-          it { is_expected.to create_svckill('svckill').with({
-            :mode => 'warning',
-            :ignore => ["goferd", "^systemd-nspawn@.*", "systemd-bootchart", "systemd-readahead-collect", "systemd-readahead-drop", "systemd-readahead-replay", "NetworkManager", "NetworkManager-dispatcher", "NetworkManager-wait-online", "microcode", "lvm2-lvmetad", "lvm2-lvmpolld", "lvm2-monitor", "kdump", "tuned", "rsyslog", "rhel-dmesg", "^autovt@.*", "amtu", "blk-availability", "dbus.*", "getty.*", "gpm", "haldaemon", "irqbalance", "killall", "libvirt-guests", "mcstrans", "mdmonitor", "messagebus", "prefdm", "netcf-transaction", "netfs", "netlabel", "network", "ntpdate", "portreserve", "restorecond", "sandbox", "sysstat", "udev-post", "krb524", "mdmpd", "readahead_later", "lm_sensors", "kudzu", "auditd", "puppet", "puppetmaster", "crond", "iptables", "ip6tables", "ebtables", "rc", "^pe-.*", "simp_client_bootstrap"],
-          })}
+          it {
+            if facts[:os][:release][:major].to_s < '7'
+              expected_ignore_list = ["goferd", "^systemd-nspawn@.*", "systemd-bootchart", "systemd-readahead-collect", "systemd-readahead-drop", "systemd-readahead-replay", "NetworkManager", "NetworkManager-dispatcher", "NetworkManager-wait-online", "microcode", "lvm2-lvmetad", "lvm2-lvmpolld", "lvm2-monitor", "kdump", "tuned", "rsyslog", "rhel-dmesg", "^autovt@.*", "amtu", "blk-availability", "dbus.*", "getty.*", "gpm", "haldaemon", "irqbalance", "killall", "libvirt-guests", "mcstrans", "mdmonitor", "messagebus", "prefdm", "netcf-transaction", "netfs", "netlabel", "network", "ntpdate", "portreserve", "restorecond", "sandbox", "sysstat", "udev-post", "krb524", "mdmpd", "readahead_later", "lm_sensors", "kudzu", "auditd", "puppet", "puppetmaster", "crond", "iptables", "ip6tables", "ebtables", "rc", "^pe-.*", "simp_client_bootstrap"]
+            else
+              expected_ignore_list = ["goferd", "^systemd-nspawn@.*", "systemd-bootchart", "systemd-readahead-collect", "systemd-readahead-drop", "systemd-readahead-replay", "NetworkManager", "NetworkManager-dispatcher", "NetworkManager-wait-online", "microcode", "lvm2-lvmetad", "lvm2-lvmpolld", "lvm2-monitor", "kdump", "tuned", "rsyslog", "rhel-autorelabel-mark", "rhel-autorelabel", "rhel-configure","rhel-dmesg","rhel-import-state","rhel-loadmodules","rhel-readonly","selinuxfsrelabel", "^autovt@.*", "amtu", "blk-availability", "dbus.*", "getty.*", "gpm", "haldaemon", "irqbalance", "killall", "libvirt-guests", "mcstrans", "mdmonitor", "messagebus", "prefdm", "netcf-transaction", "netfs", "netlabel", "network", "ntpdate", "portreserve", "restorecond", "sandbox", "sysstat", "udev-post", "krb524", "mdmpd", "readahead_later", "lm_sensors", "kudzu", "auditd", "puppet", "puppetmaster", "crond", "iptables", "ip6tables", "ebtables", "rc", "^pe-.*", "simp_client_bootstrap"] 
+            end
+            is_expected.to create_svckill('svckill').with({
+              :mode => 'warning',
+              :ignore => expected_ignore_list, 
+            })
+          }
         end
+
       end
     end
   end


### PR DESCRIPTION
  - added 7.5 rhel services to svckill::ignore_defaults
    list for EL7
  - Made beaker 4 changes for acceptance test (fact_on returns
    an object now, not a string)

SIMP-5387 #comment svckill changes submitted
SIMP-5416 #close