### PR TITLE
Remove stale ntpdate entry from RedHat ignore defaults

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 * Thu Jul 30 2026 Hazel Caballero <hazel@sicura.us> - 5.1.0
-  - Removed out of date ntpd references
+- (#131) Removed the stale `ntpdate` entry from the RedHat family
+  `svckill::ignore_defaults` (the ntp suite was dropped from the distribution
+  in EL8 and `pupmod-simp-ntpd` has been archived). Sites running ntp from
+  third-party repositories should add `ntpdate` to `svckill::ignore`
+
 * Thu Jul 09 2026 Steven Pritchard <steve@sicura.us> - 5.0.1
 - Resolved puppet-lint manifest whitespace offenses
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* Thu Jul 30 2026 Hazel Caballero <hazel@sicura.us> - 5.1.0
+  - Removed out of date ntpd references
 * Thu Jul 09 2026 Steven Pritchard <steve@sicura.us> - 5.0.1
 - Resolved puppet-lint manifest whitespace offenses
 

--- a/data/osfamily/RedHat.yaml
+++ b/data/osfamily/RedHat.yaml
@@ -28,10 +28,6 @@ svckill::ignore_defaults:
 # mcstrans service used by selinux when mctrans is installed.
   - mcstrans
 #
-# Part of the ntpd service.  Although not installed by default on
-# el8 and later, ntp can still be used and is not covered in ntpd module.
-  - ntpdate
-#
 # This is just annoying. Doesn't do anything bad (or good)
 # just annoying.
   - netcf-transaction

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-svckill",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "author": "SIMP Team",
   "summary": "Disables all services that are not controlled by Puppet.",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -12,7 +12,7 @@ describe 'svckill' do
         let(:kvm_virtual_list) { [ 'ovirt-guest-agent', 'qemu-guest-agent'] }
         let(:vmware_virtual_list) { [ 'vmtoolsd'] }
         let(:redhat_family_list) do
-          [ 'dbus.*', 'getty.*', 'irqbalance', 'gpm', 'messagebus', 'libvirt-guests', 'blk-availability', 'lvm2-lvmetad', 'lvm2-lvmpolld', 'lvm2-monitor', 'mdmonitor', 'mcstrans', 'ntpdate',
+          [ 'dbus.*', 'getty.*', 'irqbalance', 'gpm', 'messagebus', 'libvirt-guests', 'blk-availability', 'lvm2-lvmetad', 'lvm2-lvmpolld', 'lvm2-monitor', 'mdmonitor', 'mcstrans',
             'netcf-transaction', 'netlabel', 'portreserve', 'restorecond', 'sysstat', 'prefdm', 'krb524', 'mdmpd', 'readahead_later', 'lm_sensors']
         end
         let(:redhat_os_list) { [ '^rhsm*'] }


### PR DESCRIPTION
Removes the `ntpdate` entry (and its comment block) from the RedHat family `svckill::ignore_defaults` now that `pupmod-simp-ntpd` is archived and the classic ntp suite no longer ships on any supported EL release, with the matching spec expectation updated. Sites running ntp from third-party repositories can keep the old behavior by adding `ntpdate` to `svckill::ignore`. Bumps the module to 5.1.0.

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)